### PR TITLE
New feature: private key to public key and address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ solang-parser = "0.1.18"
 
 ethers = { path = "ethers-rs", default-features = false, features = ["solc-full"]}
 walkdir = "2.3.2"
-
+secp256k1 = "0.26.0"
+hex = "0.4.3"
+sha3 = "0.10.6"
 
 #ethers-solc = { path = "/Users/ethnical/Sec/Rust/oz_implementations/ethers-rs/ethers-solc/"}
 [build]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod contract2interface;
 mod contractinfo;
 mod eth_call_json;
 mod mempool_watcher;
+mod private_key_to_address;
 #[derive(clap::Parser)]
 
 struct Cli {
@@ -57,6 +58,12 @@ struct ContractInfoContractArgs {
     #[clap(short, long, default_value = "external,public,internal,private")]
     visibility: String,
 }
+#[derive(clap::Parser)]
+struct PrivateKey2AddressArgs {
+    #[clap(short, long)]
+    /// Address
+    address: String,
+}
 
 #[derive(clap::Subcommand)]
 enum Commands {
@@ -72,6 +79,8 @@ enum Commands {
     AnalyzeVerifiedContract(LinkContractArgs),
     /// Tools to displays functions list,modifiers, crisk etc..
     ContractInfo(ContractInfoContractArgs),
+    /// Convert a private key to an address
+    PrivatekeyToAddress(PrivateKey2AddressArgs),
 }
 
 fn main() {
@@ -101,6 +110,9 @@ fn main() {
                 args.contract,
                 args.visibility,
             );
+        }
+        Commands::PrivatekeyToAddress(args) => {
+            private_key_to_address::exec_private_key_to_address(&args.address);
         } //  mempool_watcher::exec_module_watcher_mempool(args.interval);
           // }
     }

--- a/src/private_key_to_address.rs
+++ b/src/private_key_to_address.rs
@@ -1,0 +1,29 @@
+use colored::Colorize;
+
+use hex;
+use secp256k1::{PublicKey, SecretKey};
+use sha3::{Digest, Keccak256};
+use std::str::FromStr;
+
+pub fn exec_private_key_to_address(private_key: &str) {
+    let mut private_key = private_key;
+    println!("Private key: {}", private_key.yellow());
+    if private_key.starts_with("0x") {
+        private_key = &private_key[2..];
+    }
+    let context = secp256k1::Secp256k1::new();
+    let secret_key = SecretKey::from_str(private_key).expect("Fail to parse the secret key");
+    let public_key = PublicKey::from_secret_key(&context, &secret_key);
+    println!(
+        "Public key uncompressed: {}",
+        Colorize::green(&hex::encode(public_key.serialize_uncompressed())[..])
+    );
+    println!(
+        "Public key compressed: {}",
+        Colorize::green(&hex::encode(public_key.serialize())[..])
+    );
+    // Take the keccak256 of the public key uncompressed. The first two characters should be removed. This is because the 04 is a tag bytes for the ASN.1 OCTET String structure.
+    let address =
+        hex::encode(&Keccak256::digest(&public_key.serialize_uncompressed()[1..]).as_slice()[12..]);
+    println!("Address: {}", Colorize::blue(&address[..]));
+}


### PR DESCRIPTION
Add feature to convert private key to public key and address

![swek3](https://user-images.githubusercontent.com/7670696/220184760-2c9bf378-3d30-4413-a59b-32f3a96f95bf.png)

The value was validated with https://toolkit.abdk.consulting/ethereum#rlp,recover-address,key-to-address.
![abdk-consulting](https://user-images.githubusercontent.com/7670696/220185112-4702e2e2-8eeb-426b-992c-9e8e7d69cb3e.png)
